### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,6 +1,7 @@
 {
     "name": "Print Progress and Error",
     "type": "app",
+    "instance_version": "6.15.60",
     "categories": [
         "development"
     ],

--- a/config.json
+++ b/config.json
@@ -5,7 +5,7 @@
         "development"
     ],
     "description": "Prints progress and then raises error",
-    "docker_image": "supervisely/development:0.0.1",
+    "docker_image": "supervisely/development:6.73.564",
     "main_script": "src/main_dpe.py",
     "task_location": "workspace_tasks",
     "isolate": true,

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,1 @@
-supervisely==6.72.85
+supervisely==6.73.564


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
